### PR TITLE
Update `selector-pseudo-element-colon-notation` to use `double`

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ module.exports = {
 		'selector-pseudo-class-case': 'lower',
 		'selector-pseudo-class-parentheses-space-inside': 'never',
 		'selector-pseudo-element-case': 'lower',
-		'selector-pseudo-element-colon-notation': 'single',
+		'selector-pseudo-element-colon-notation': 'double',
 		'selector-type-case': 'lower',
 		'string-quotes': 'double',
 		'unit-case': 'lower',


### PR DESCRIPTION
Fixes #165